### PR TITLE
Upgrade pathwatcher for Atom 0.121 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-blueprint-preview",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./lib/api-blueprint-preview",
   "description": "Open a rendered version of the API Blueprint in the current editor with `ctrl-shift-a`.",
   "repository": "https://github.com/danielgtaylor/atom-api-blueprint-preview",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "fs-plus": "2.x",
-    "pathwatcher": "0.16.0",
+    "pathwatcher": "2.x",
     "temp": "0.6.x",
     "underscore-plus": "1.x",
     "wrench": "1.5.x"


### PR DESCRIPTION
... also bumped the package version.

Otherwise, the package refuses to load in the latest Atom.
