### PR TITLE
extend maxBuffer size

### DIFF
--- a/lib/api-blueprint-preview-view.coffee
+++ b/lib/api-blueprint-preview-view.coffee
@@ -84,8 +84,10 @@ class ApiBlueprintPreviewView extends ScrollView
     # Env hack... helps find aglio binary
     env =
         PATH: process.env.PATH + ':/usr/local/bin'
+    options =
+        maxBuffer: 2 * 1024 * 1024 # Default: 200*1024
     template = "#{path.dirname __dirname}/templates/api-blueprint-preview.jade"
-    exec "aglio -i /tmp/atom.apib -t #{template} -o -", {env}, (err, stdout, stderr) =>
+    exec "aglio -i /tmp/atom.apib -t #{template} -o -", {env, options}, (err, stdout, stderr) =>
       if err
         @showError(err)
       else


### PR DESCRIPTION
I got unexpected error.

```
Previewing ApiBlueprint Failed

stdout maxBuffer exceeded.
```

my environment.

```
$ ls -la apiary.apib
-rw-r--r--  1 vvakame  staff  121066 12  3 12:05 apiary.apib
$ aglio -i apiary.apib -o tmp.html
$ ls -la tmp.html
-rw-r--r--  1 vvakame  staff  402275 12  3 15:05 tmp.html
```

http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
> maxBuffer Number (Default: 200*1024)

I want resolve it.
