### PR TITLE
Look for aglio binary in project local Node modules

### DIFF
--- a/lib/api-blueprint-preview-view.coffee
+++ b/lib/api-blueprint-preview-view.coffee
@@ -83,8 +83,8 @@ class ApiBlueprintPreviewView extends ScrollView
     fs.writeFileSync '/tmp/atom.apib', text
     # Env hack... helps find aglio binary
     env = Object.create(process.env)
-    npm_bin = atom.project.getPaths().map (p) -> "#{path.join(p, 'node_modules', '.bin')}:"
-    env.PATH = "#{npm_bin.join()}#{env.PATH}:/usr/local/bin"
+    npm_bin = atom.project.getPaths().map (p) -> path.join(p, 'node_modules', '.bin')
+    env.PATH = npm_bin.concat(env.PATH, '/usr/local/bin').join(path.delimiter)
     template = "#{path.dirname __dirname}/templates/api-blueprint-preview.jade"
     exec "aglio -i /tmp/atom.apib -t #{template} -o -", {env}, (err, stdout, stderr) =>
       if err

--- a/lib/api-blueprint-preview-view.coffee
+++ b/lib/api-blueprint-preview-view.coffee
@@ -82,8 +82,9 @@ class ApiBlueprintPreviewView extends ScrollView
   renderApiBlueprintText: (text) ->
     fs.writeFileSync '/tmp/atom.apib', text
     # Env hack... helps find aglio binary
-    env =
-        PATH: process.env.PATH + ':/usr/local/bin'
+    env = Object.create(process.env)
+    npm_bin = atom.project.getPaths().map (p) -> "#{path.join(p, 'node_modules', '.bin')}:"
+    env.PATH = "#{npm_bin.join()}#{env.PATH}:/usr/local/bin"
     template = "#{path.dirname __dirname}/templates/api-blueprint-preview.jade"
     exec "aglio -i /tmp/atom.apib -t #{template} -o -", {env}, (err, stdout, stderr) =>
       if err


### PR DESCRIPTION
This adds the projects local `node_modules/.bin` folder to the env PATH, so that if the user only has Aglio installed locally for the project, the plugin will still work.

Also fixes an issue with how the `env` was passed to `exec`.