### PR TITLE
Adds support for Aglio's "include" directive

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -22,7 +22,8 @@ exports.toHTML = (text='', filePath, grammar, callback) ->
   render text, filePath, callback
 
 render = (text, filePath, callback) ->
-  fs.writeFileSync '/tmp/atom.apib', text
+  tempFile = '/tmp/atom.apib'
+  fs.writeFileSync tempFile, text
   # Env hack... helps find aglio binary
   options =
       maxBuffer: 2 * 1024 * 1024 # Default: 200*1024
@@ -34,6 +35,7 @@ render = (text, filePath, callback) ->
   exec "aglio -i #{tempFile} -t #{template} -n #{includePath} -o -", {env, options}, (err, stdout, stderr) =>
     if err then return callback(err)
     console.log stderr
+    fs.removeSync tempFile
     callback null, resolveImagePaths(stdout)
 
 resolveImagePaths = (html, filePath) ->

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -30,7 +30,8 @@ render = (text, filePath, callback) ->
   npm_bin = atom.project.getPaths().map (p) -> path.join(p, 'node_modules', '.bin')
   env.PATH = npm_bin.concat(env.PATH, '/usr/local/bin').join(path.delimiter)
   template = "#{path.dirname __dirname}/templates/api-blueprint-preview.jade"
-  exec "aglio -i /tmp/atom.apib -t #{template} -o -", {env, options}, (err, stdout, stderr) =>
+  includePath = path.dirname filePath # for Aglio include directives
+  exec "aglio -i #{tempFile} -t #{template} -n #{includePath} -o -", {env, options}, (err, stdout, stderr) =>
     if err then return callback(err)
     console.log stderr
     callback null, resolveImagePaths(stdout)


### PR DESCRIPTION
- Resolves a crash when using the `include` directive in a large API Blueprint project split into multiple files.

- Cleans up the temporary file used during rendering.

Note: This requires Aglio 2.1.0 or higher, with support for the `-n` command line option.