### PR TITLE
maxBuffer should be passed to exec() correctly

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -25,14 +25,13 @@ render = (text, filePath, callback) ->
   tempFile = '/tmp/atom.apib'
   fs.writeFileSync tempFile, text
   # Env hack... helps find aglio binary
-  options =
-      maxBuffer: 2 * 1024 * 1024 # Default: 200*1024
+  maxBuffer = 2 * 1024 * 1024 # Default: 200*1024
   env = Object.create(process.env)
   npm_bin = atom.project.getPaths().map (p) -> path.join(p, 'node_modules', '.bin')
   env.PATH = npm_bin.concat(env.PATH, '/usr/local/bin').join(path.delimiter)
   template = "#{path.dirname __dirname}/templates/api-blueprint-preview.jade"
   includePath = path.dirname filePath # for Aglio include directives
-  exec "aglio -i #{tempFile} -t #{template} -n #{includePath} -o -", {env, options}, (err, stdout, stderr) =>
+  exec "aglio -i #{tempFile} -t #{template} -n #{includePath} -o -", {env, maxBuffer}, (err, stdout, stderr) =>
     if err then return callback(err)
     console.log stderr
     fs.removeSync tempFile


### PR DESCRIPTION
Fixes danielgtaylor/atom-api-blueprint-preview#44

{env, options} was previously incorrectly expanding to "options: {options: {maxBuffer: ...}}" when being passed to child.process.exec()

now it's passed correctly as "options: {maxBuffer: ...}"

maxBuffer is still not "infinity" but at least it is being passed correctly now and works for much bigger files
**solving "stdout maxBuffer exceeded" issue**